### PR TITLE
Update cmake configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Build and Test
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Build and Test (Legacy)
         run: |
           make -f ./make/vm-x86-gfortran-gcc.mk check
+
+      - name: Build (CMake)
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+          cmake --build build --config Release -j $(nproc)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,4 +31,4 @@ jobs:
         run: |
           cmake --preset debug-gcc
           cmake --build --preset debug-gcc --parallel
-          ctest --test-dir build/debug --output-on-failure -V
+          ctest --test-dir ../build-shumlib-debug-gcc --output-on-failure -V

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,8 @@ jobs:
         run: |
           make -f ./make/vm-x86-gfortran-gcc.mk check
 
-      - name: Build (CMake)
+      - name: Build & Test (CMake)
         run: |
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
-          cmake --build build --config Release -j $(nproc)
+          cmake --preset debug-gcc -DBUILD_FTHREADS=ON --log-level=VERBOSE
+          cmake --build --preset debug-gcc
+          ctest --preset debug-gcc -V

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 _build/
 build/
 
+Testing/
+
 # Virtual environment
 .venv/
 uv.lock

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,3 +110,39 @@ if(BUILD_TESTS)
     ENVIRONMENT SHUM_TMPDIR=/tmp)
 
 endif()
+
+# Generate legacy compatibility header for wgdos version API.
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/common/src/c_shum_wgdos_packing_version.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/c_shum_wgdos_packing_version.h
+  @ONLY
+)
+
+# Install additional headers expected by downstream users.
+install(FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/common/src/shumlib_version.h
+  ${CMAKE_CURRENT_BINARY_DIR}/c_shum_wgdos_packing_version.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Install standalone sub-libraries requested by packaging.
+install(TARGETS
+  shum_constants
+  shum_string_conv
+  shum_wgdos_packing
+  shum_byteswap
+  shum_spiral_search
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+# Create install prefix symlink: lib -> lib64 (when lib64 exists).
+# Variables are escaped (\$) so they evaluate at install time, not configure time.
+install(CODE
+"if(EXISTS \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib64\"
+    AND NOT EXISTS \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib\")
+  execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
+    lib64 \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/lib\")
+endif()"
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,11 +117,18 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/c_shum_wgdos_packing_version.h
   @ONLY
 )
+# Generate legacy compatibility header for data conversion version API.
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/common/src/c_shum_data_conv_version.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/c_shum_data_conv_version.h
+  @ONLY
+)
 
 # Install additional headers expected by downstream users.
 install(FILES
   ${CMAKE_CURRENT_SOURCE_DIR}/common/src/shumlib_version.h
   ${CMAKE_CURRENT_BINARY_DIR}/c_shum_wgdos_packing_version.h
+  ${CMAKE_CURRENT_BINARY_DIR}/c_shum_data_conv_version.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
@@ -132,6 +139,7 @@ install(TARGETS
   shum_wgdos_packing
   shum_byteswap
   shum_spiral_search
+  shum_data_conv
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,11 +1,18 @@
 {
-    "version": 2,
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 21,
+        "patch": 0
+    },
     "configurePresets": [
         {
-            "name": "debug",
-            "displayName": "Debug",
+            "name": "base-debug",
+            "displayName": "Base Debug Configuration",
+            "description": "Abstract base preset for debug builds",
+            "hidden": true,
             "generator": "Unix Makefiles",
-            "binaryDir": "build/debug",
+            "binaryDir": "${sourceParentDir}/build-${sourceDirName}-${presetName}",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug"
             }
@@ -13,21 +20,19 @@
         {
             "name": "debug-gcc",
             "displayName": "GCC Debug",
-            "inherits": "debug",
+            "inherits": "base-debug",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_C_COMPILER": "gcc",
                 "CMAKE_Fortran_COMPILER": "gfortran",
-                "CMAKE_C_FLAGS_INIT": "-g -Wall -Wextra -Werror -Wformat=2 -Winit-self -Wfloat-equal -Wpointer-arith -Wbad-function-cast -Wcast-qual -Wcast-align -Wconversion -Wlogical-op -Wstrict-prototypes -Wmissing-declarations -Wredundant-decls -Wnested-externs -Woverlength-strings -Wshadow -Wall -Wextra -Wpedantic -fdiagnostics-show-option",
+                "CMAKE_C_FLAGS_INIT": "-g -Wall -Wextra -Werror -Wformat=2 -Winit-self -Wfloat-equal -Wpointer-arith -Wbad-function-cast -Wcast-qual -Wcast-align -Wconversion -Wlogical-op -Wstrict-prototypes -Wmissing-declarations -Wredundant-decls -Wnested-externs -Woverlength-strings -Wshadow -Wpedantic -fdiagnostics-show-option",
                 "CMAKE_Fortran_FLAGS_INIT": "-g -std=f2018 -pedantic -pedantic-errors -fno-range-check -Wall -Wextra -Werror -Wno-compare-reals -Wconversion -Wno-unused-dummy-argument -Wno-c-binding-type -fdiagnostics-show-option"
             }
         },
         {
             "name": "debug-cce",
             "displayName": "Cray CCE Debug",
-            "inherits": "debug",
+            "inherits": "base-debug",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_C_COMPILER": "cc",
                 "CMAKE_Fortran_COMPILER": "ftn",
                 "CMAKE_C_FLAGS_INIT": "-g -Weverything -Wno-vla -Wno-padded -Wno-missing-noreturn -Wno-declaration-after-statement -Werror -pedantic -pedantic-errors -fdiagnostics-show-option -DSHUM_X86_INTRINSIC",
@@ -37,9 +42,19 @@
         {
             "name": "debug-nvhpc",
             "displayName": "nvidia HPC Debug",
-            "inherits": "debug",
+            "inherits": "base-debug",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_C_COMPILER": "nvc",
+                "CMAKE_Fortran_COMPILER": "nvfortran",
+                "CMAKE_C_FLAGS_INIT": "-g -Minform=inform",
+                "CMAKE_Fortran_FLAGS_INIT": "-g -Minform=inform"
+            }
+        },
+        {
+            "name": "debug-nvhpcc",
+            "displayName": "nvidia HPC Cuda Debug",
+            "inherits": "base-debug",
+            "cacheVariables": {
                 "CMAKE_C_COMPILER": "nvcc",
                 "CMAKE_Fortran_COMPILER": "nvfortran",
                 "CMAKE_C_FLAGS_INIT": "-g",
@@ -49,22 +64,71 @@
     ],
     "buildPresets": [
         {
+            "name": "base-build",
+            "hidden": true,
+            "jobs": 0
+        },
+        {
             "name": "debug-gcc",
             "displayName": "GCC Debug Build",
-            "configurePreset": "debug",
-            "configuration": "Debug"
+            "inherits": "base-build",
+            "configurePreset": "debug-gcc"
         },
         {
             "name": "debug-cce",
             "displayName": "Cray CCE Debug Build",
-            "configurePreset": "debug",
-            "configuration": "Debug"
+            "inherits": "base-build",
+            "configurePreset": "debug-cce"
         },
         {
             "name": "debug-nvhpc",
             "displayName": "nvidia HPC Debug Build",
-            "configurePreset": "debug",
-            "configuration": "Debug"
+            "inherits": "base-build",
+            "configurePreset": "debug-nvhpc"
+        },
+        {
+            "name": "debug-nvhpcc",
+            "displayName": "nvidia HPC Cuda Debug Build",
+            "inherits": "base-build",
+            "configurePreset": "debug-nvhpcc"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "base-test",
+            "hidden": true,
+            "execution": {
+                "stopOnFailure": false,
+                "jobs": 0,
+                "noTestsAction": "error"
+            },
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "debug-gcc",
+            "displayName": "GCC Debug Tests",
+            "inherits": "base-test",
+            "configurePreset": "debug-gcc"
+        },
+        {
+            "name": "debug-cce",
+            "displayName": "Cray CCE Debug Tests",
+            "inherits": "base-test",
+            "configurePreset": "debug-cce"
+        },
+        {
+            "name": "debug-nvhpc",
+            "displayName": "nvidia HPC Debug Tests",
+            "inherits": "base-test",
+            "configurePreset": "debug-nvhpc"
+        },
+        {
+            "name": "debug-nvhpcc",
+            "displayName": "nvidia HPC Cuda Debug Tests",
+            "inherits": "base-test",
+            "configurePreset": "debug-nvhpcc"
         }
     ]
 }

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@
 | james-bruten-mo | James Bruten | Met Office | 2025-12-09 |
 | t00sa | Sam Clarke-Green | Met Office | 2026-02-10 |
 | jennyhickson | Jenny Hickson | Met Office | 2026-03-02 |
+| yaswant | Yaswant Pradhan | Met Office | 2026-07-10 |

--- a/cmake/ShumOptions.cmake
+++ b/cmake/ShumOptions.cmake
@@ -41,7 +41,44 @@ endif()
 
 if(BUILD_OPENMP)
   # FIXME: this probably needs newer version of cmake on the Cray
-  find_package(OpenMP 3.0 REQUIRED)
+  # UPDATE: Doesn't work with cmake 3.31.9
+  # A little hack to check supported OMP spec on Cray
+  # ---
+  if(CMAKE_Fortran_COMPILER_ID MATCHES "Cray" OR CMAKE_C_COMPILER_ID MATCHES "Cray")
+    # Cray's OpenMP is compiler-managed (no separate runtime library).
+    # CMake's FindOpenMP fails on Cray because it can't resolve LIB_NAMES.
+    # Verify the minimum required OpenMP spec date manually instead.
+    # See OpenMP Spec dates <https://www.openmp.org/specifications/>
+    include(CheckFortranSourceRuns)
+    set(CMAKE_REQUIRED_FLAGS "-homp")
+    check_fortran_source_runs(
+      "program check\n  if (_OPENMP < 200805) stop 1\nend program\n"
+      CRAY_OMP_MEETS_MINIMUM SRC_EXT F90
+    )
+    unset(CMAKE_REQUIRED_FLAGS)
+    if(NOT CRAY_OMP_MEETS_MINIMUM)
+      message(FATAL_ERROR "shumlib requires OpenMP >= 3.0 (date 200805); Cray compiler does not meet this.")
+    endif()
+
+    # Create the standard imported targets so downstream consumers work normally
+    if(NOT TARGET OpenMP::OpenMP_Fortran)
+      add_library(OpenMP::OpenMP_Fortran INTERFACE IMPORTED)
+      set_target_properties(OpenMP::OpenMP_Fortran PROPERTIES
+        INTERFACE_COMPILE_OPTIONS "-homp"
+        INTERFACE_LINK_OPTIONS   "-homp")
+    endif()
+    if(NOT TARGET OpenMP::OpenMP_C)
+      add_library(OpenMP::OpenMP_C INTERFACE IMPORTED)
+      set_target_properties(OpenMP::OpenMP_C PROPERTIES
+        INTERFACE_COMPILE_OPTIONS "-fopenmp"
+        INTERFACE_LINK_OPTIONS   "-fopenmp")
+    endif()
+    set(OpenMP_FOUND TRUE)
+    set(OpenMP_Fortran_FOUND TRUE)
+    set(OpenMP_C_FOUND TRUE)
+  else()
+    find_package(OpenMP 3.0 REQUIRED)
+  endif()
 
   if(BUILD_FTHREADS)
     message(VERBOSE "Using shumlib with Fortran OpenMP threading")

--- a/common/src/c_shum_data_conv_version.h.in
+++ b/common/src/c_shum_data_conv_version.h.in
@@ -1,0 +1,14 @@
+#ifndef C_SHUM_DATA_CONV_VERSION_H
+#define C_SHUM_DATA_CONV_VERSION_H
+
+#if !defined(SHUMLIB_VERSION)
+#define SHUMLIB_VERSION @SHUMLIB_VERSION@
+#endif
+
+#define SHUMLIB_CMAKE 1
+#include "shumlib_version.h"
+#undef SHUMLIB_CMAKE
+
+#define get_shum_data_conv_version GET_SHUMLIB_VERSION
+
+#endif

--- a/common/src/c_shum_wgdos_packing_version.h.in
+++ b/common/src/c_shum_wgdos_packing_version.h.in
@@ -1,0 +1,20 @@
+#ifndef C_SHUM_WGDOS_PACKING_VERSION_H
+#define C_SHUM_WGDOS_PACKING_VERSION_H
+
+/* Ensure downstream consumers do not need to define SHUMLIB_VERSION */
+#if !defined(SHUMLIB_VERSION)
+#define SHUMLIB_VERSION @SHUMLIB_VERSION@
+#endif
+
+/*
+ * Reuse the CMake-mode API in shumlib_version.h and expose the legacy
+ * function-like name expected by external applications.
+ */
+#define SHUMLIB_CMAKE 1
+#include "shumlib_version.h"
+#undef SHUMLIB_CMAKE
+
+/* Legacy compatibility symbol name */
+#define get_shum_wgdos_packing_version GET_SHUMLIB_VERSION
+
+#endif

--- a/shum_byteswap/src/CMakeLists.txt
+++ b/shum_byteswap/src/CMakeLists.txt
@@ -15,3 +15,20 @@ target_sources(shum
   FILES
   c_shum_byteswap.h
   c_shum_byteswap_opt.h)
+
+add_library(shum_byteswap)
+target_sources(shum_byteswap
+  PRIVATE
+  c_shum_byteswap.c
+  f_shum_byteswap.f90
+  ${PROJECT_SOURCE_DIR}/common/src/shumlib_version.c
+  ${PROJECT_BINARY_DIR}/f_shum_byteswap_version_mod.f90)
+
+target_compile_definitions(shum_byteswap PUBLIC ${SHUM_DEFINES})
+
+target_include_directories(shum_byteswap
+  PUBLIC
+  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_SOURCE_DIR}/common/src)
+
+target_link_libraries(shum_byteswap PUBLIC shum_string_conv)

--- a/shum_byteswap/src/CMakeLists.txt
+++ b/shum_byteswap/src/CMakeLists.txt
@@ -26,9 +26,12 @@ target_sources(shum_byteswap
 
 target_compile_definitions(shum_byteswap PUBLIC ${SHUM_DEFINES})
 
+set_target_properties(shum_byteswap PROPERTIES
+  Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules_shum_byteswap)
+
 target_include_directories(shum_byteswap
   PUBLIC
-  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_BINARY_DIR}/modules_shum_byteswap
   ${PROJECT_SOURCE_DIR}/common/src)
 
 target_link_libraries(shum_byteswap PUBLIC shum_string_conv)

--- a/shum_constants/src/CMakeLists.txt
+++ b/shum_constants/src/CMakeLists.txt
@@ -26,7 +26,10 @@ target_sources(shum_constants
 
 target_compile_definitions(shum_constants PUBLIC ${SHUM_DEFINES})
 
+set_target_properties(shum_constants PROPERTIES
+  Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules_shum_constants)
+
 target_include_directories(shum_constants
   PUBLIC
-  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_BINARY_DIR}/modules_shum_constants
   ${PROJECT_SOURCE_DIR}/common/src)

--- a/shum_constants/src/CMakeLists.txt
+++ b/shum_constants/src/CMakeLists.txt
@@ -11,3 +11,22 @@ target_sources(shum
   f_shum_ztables.f90
   f_shum_rel_mol_mass_mod.f90
   f_shum_water_constants_mod.f90)
+
+add_library(shum_constants)
+target_sources(shum_constants
+  PRIVATE
+  f_shum_chemistry_constants_mod.f90
+  f_shum_conversions_mod.f90
+  f_shum_planet_earth_constants_mod.f90
+  f_shum_ztables.f90
+  f_shum_rel_mol_mass_mod.f90
+  f_shum_water_constants_mod.f90
+  ${PROJECT_SOURCE_DIR}/common/src/shumlib_version.c
+  ${PROJECT_BINARY_DIR}/f_shum_constants_version_mod.f90)
+
+target_compile_definitions(shum_constants PUBLIC ${SHUM_DEFINES})
+
+target_include_directories(shum_constants
+  PUBLIC
+  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_SOURCE_DIR}/common/src)

--- a/shum_data_conv/src/CMakeLists.txt
+++ b/shum_data_conv/src/CMakeLists.txt
@@ -25,7 +25,12 @@ target_sources(shum_data_conv
 
 target_compile_definitions(shum_data_conv PUBLIC ${SHUM_DEFINES})
 
+set_target_properties(shum_data_conv PROPERTIES
+  Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules_shum_data_conv)
+
 target_include_directories(shum_data_conv
   PUBLIC
-  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_BINARY_DIR}/modules_shum_data_conv
   ${PROJECT_SOURCE_DIR}/common/src)
+
+target_link_libraries(shum_data_conv PUBLIC shum_string_conv)

--- a/shum_data_conv/src/CMakeLists.txt
+++ b/shum_data_conv/src/CMakeLists.txt
@@ -14,3 +14,18 @@ target_sources(shum
   TYPE HEADERS
   FILES
   c_shum_data_conv.h)
+
+add_library(shum_data_conv)
+target_sources(shum_data_conv
+  PRIVATE
+  c_shum_data_conv.c
+  f_shum_data_conv.f90
+  ${PROJECT_SOURCE_DIR}/common/src/shumlib_version.c
+  ${PROJECT_BINARY_DIR}/f_shum_data_conv_version_mod.f90)
+
+target_compile_definitions(shum_data_conv PUBLIC ${SHUM_DEFINES})
+
+target_include_directories(shum_data_conv
+  PUBLIC
+  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_SOURCE_DIR}/common/src)

--- a/shum_spiral_search/src/CMakeLists.txt
+++ b/shum_spiral_search/src/CMakeLists.txt
@@ -25,9 +25,12 @@ target_sources(shum_spiral_search
 
 target_compile_definitions(shum_spiral_search PUBLIC ${SHUM_DEFINES})
 
+set_target_properties(shum_spiral_search PROPERTIES
+  Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules_shum_spiral_search)
+
 target_include_directories(shum_spiral_search
   PUBLIC
-  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_BINARY_DIR}/modules_shum_spiral_search
   ${PROJECT_SOURCE_DIR}/common/src)
 
 target_link_libraries(shum_spiral_search PUBLIC shum_constants shum_string_conv)

--- a/shum_spiral_search/src/CMakeLists.txt
+++ b/shum_spiral_search/src/CMakeLists.txt
@@ -14,3 +14,20 @@ target_sources(shum
   TYPE HEADERS
   FILES
   c_shum_spiral_search.h)
+
+add_library(shum_spiral_search)
+target_sources(shum_spiral_search
+  PRIVATE
+  f_shum_spiral_search.f90
+  c_shum_spiral_search.f90
+  ${PROJECT_SOURCE_DIR}/common/src/shumlib_version.c
+  ${PROJECT_BINARY_DIR}/f_shum_spiral_search_version_mod.f90)
+
+target_compile_definitions(shum_spiral_search PUBLIC ${SHUM_DEFINES})
+
+target_include_directories(shum_spiral_search
+  PUBLIC
+  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_SOURCE_DIR}/common/src)
+
+target_link_libraries(shum_spiral_search PUBLIC shum_constants shum_string_conv)

--- a/shum_string_conv/src/CMakeLists.txt
+++ b/shum_string_conv/src/CMakeLists.txt
@@ -16,7 +16,10 @@ target_sources(shum_string_conv
 
 target_compile_definitions(shum_string_conv PUBLIC ${SHUM_DEFINES})
 
+set_target_properties(shum_string_conv PROPERTIES
+  Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules_shum_string_conv)
+
 target_include_directories(shum_string_conv
   PUBLIC
-  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_BINARY_DIR}/modules_shum_string_conv
   ${PROJECT_SOURCE_DIR}/common/src)

--- a/shum_string_conv/src/CMakeLists.txt
+++ b/shum_string_conv/src/CMakeLists.txt
@@ -6,3 +6,17 @@
 target_sources(shum
   PRIVATE
   f_shum_string_conv.f90)
+
+add_library(shum_string_conv)
+target_sources(shum_string_conv
+  PRIVATE
+  f_shum_string_conv.f90
+  ${PROJECT_SOURCE_DIR}/common/src/shumlib_version.c
+  ${PROJECT_BINARY_DIR}/f_shum_string_conv_version_mod.f90)
+
+target_compile_definitions(shum_string_conv PUBLIC ${SHUM_DEFINES})
+
+target_include_directories(shum_string_conv
+  PUBLIC
+  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_SOURCE_DIR}/common/src)

--- a/shum_wgdos_packing/src/CMakeLists.txt
+++ b/shum_wgdos_packing/src/CMakeLists.txt
@@ -25,9 +25,12 @@ target_sources(shum_wgdos_packing
 
 target_compile_definitions(shum_wgdos_packing PUBLIC ${SHUM_DEFINES})
 
+set_target_properties(shum_wgdos_packing PROPERTIES
+  Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules_shum_wgdos_packing)
+
 target_include_directories(shum_wgdos_packing
   PUBLIC
-  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_BINARY_DIR}/modules_shum_wgdos_packing
   ${PROJECT_SOURCE_DIR}/common/src)
 
 target_link_libraries(shum_wgdos_packing PUBLIC shum_constants shum_string_conv)

--- a/shum_wgdos_packing/src/CMakeLists.txt
+++ b/shum_wgdos_packing/src/CMakeLists.txt
@@ -14,3 +14,20 @@ target_sources(shum
   TYPE HEADERS
   FILES
   c_shum_wgdos_packing.h)
+
+add_library(shum_wgdos_packing)
+target_sources(shum_wgdos_packing
+  PRIVATE
+  c_shum_wgdos_packing.f90
+  f_shum_wgdos_packing.f90
+  ${PROJECT_SOURCE_DIR}/common/src/shumlib_version.c
+  ${PROJECT_BINARY_DIR}/f_shum_wgdos_packing_version_mod.f90)
+
+target_compile_definitions(shum_wgdos_packing PUBLIC ${SHUM_DEFINES})
+
+target_include_directories(shum_wgdos_packing
+  PUBLIC
+  ${CMAKE_Fortran_MODULE_DIRECTORY}
+  ${PROJECT_SOURCE_DIR}/common/src)
+
+target_link_libraries(shum_wgdos_packing PUBLIC shum_constants shum_string_conv)


### PR DESCRIPTION
# PR Summary

This change finishes the CMake install parity work so downstream consumers (e.g., Mule) get the same critical install artifacts expected from the legacy build flow.

Code Reviewer: @t00sa 

## What's changed

1. Added installation of standalone shared libraries for key subcomponents:
   - `libshum_constants.so`
   - `libshum_string_conv.so`
   - `libshum_wgdos_packing.so`
   - `libshum_byteswap.so`
   - `libshum_spiral_search.so`
2. Added installation of missing public headers:
   - `shumlib_version.h`
   - `c_shum_wgdos_packing_version.h`
3. Optionally, added generation of the WGDOS version compatibility header from a template, and ensured it defines `SHUMLIB_VERSION` for external consumers before including `shumlib_version.h`.
4. Added install-time symlink creation so the install prefix contains:
   - `lib64` directory for libraries
   - `lib` symlink pointing to `lib64`
5. Fixed source/include path handling for new sub-library CMake targets to use project-root-qualified paths, preventing missing-source errors during configure/build.

This keeps the existing aggregate library behaviour while adding/installing the required standalone targets and compatibility headers needed by downstream users.

I'll add an example wrapper script in MetOffice/mule in a separate Mule PR.

### Checks
- [x] Configure/build/install succeeds with CMake.
- [x] Install tree contains the expected five shared libraries in lib64.
- [x] Install tree contains the expected headers in include.
- [x] Prefix contains lib symlink to lib64.

<!-- List any linked PRs here
- linked MetOffice/<REPO-NAME>#<pr-number>
-->

<!-- List any blocking PRs or issues to be closed here
- is blocked-by #pr-number
- blocks #pr-number
- closes #issue-number
- fixes #issue-number
- is related to #issue-number
-->

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [ ] I have performed a self-review of my own code
- [ ] My code follows the project's style guidelines
- [ ] Comments have been included that aid undertanding and enhance the
      readability of the code
- [ ] My changes generate no new warnings

## Testing

- [ ] I have tested this change locally, using the rose-stem suite
- [ ] If any tests fail (rose-stem or CI) the reason is understood and
      acceptable (eg. kgo changes)
- [ ] I have added tests to cover new functionality as appropriate (eg. system
      tests, unit tests, etc.)

<!-- Describe other testing performed (if applicable) -->

### trac.log

<!-- Paste your trac.log from testing output here -->

## Security Considerations

- [ ] This change does not introduce security vulnerabilities
- [ ] I have reviewed the code for potential security issues
- [ ] Sensitive data is properly handled (if applicable)
- [ ] Authentication and authorisation are properly implemented (if applicable)

## Performance Impact

- [ ] Performance of the code has been considered and, if applicable, suitable
      performance measurements have been conducted

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html)(including attribution labels)

<!-- If AI has been used, please provide more details here -->

## Documentation

- [ ] Where appropriate I have updated documentation related to this change and
      confirmed that it builds correctly

# Code Review

<!-- To be completed by the Code Reviewer -->

- [ ] All dependencies have been resolved
- [ ] Related Issues have been properly linked and addressed
- [ ] CLA compliance has been confirmed
- [ ] Code quality standards have been met
- [ ] Tests are adequate and have passed
- [ ] Documentation is complete and accurate
- [ ] Security considerations have been addressed
- [ ] Performance impact is acceptable
